### PR TITLE
BUGFIX: Cookie stripper doesn't always handle cookies

### DIFF
--- a/lib/middleware/cookie_domain_stripper.js
+++ b/lib/middleware/cookie_domain_stripper.js
@@ -3,14 +3,14 @@
 module.exports = function() {
     return function(req, res, next) {
         var oldWriteHead = res.writeHead;
-        res.writeHead = function(statusCode, headers) {
-            var cookies = headers && headers['set-cookie'];
+        res.writeHead = function() {
+            var cookies = res.getHeader('set-cookie');
             if (cookies) {
                 var modified = cookies.map(function(cookie) {
                     return cookie.replace(/(domain=[^ ]+; )/mg, '');
                 });
 
-                headers['set-cookie'] = modified;
+                res.setHeader('set-cookie', modified);
             }
 
             // Call original function


### PR DESCRIPTION
I don't know exactly why but in some configurations `writeHead` method
doesn't get `headers` arguments as promised by API doc - hence current
`writeHead` method will fail now.

This PR fixes behavior for all situations.

For more, see [this SO thread](http://stackoverflow.com/a/7086621) and source of `_writeHead` in joyent's node
repo.
