### PR TITLE
BUGFIX: CL-4033 Do not send duplicate cookies in the response

### DIFF
--- a/lib/middleware/cookie_domain_stripper.js
+++ b/lib/middleware/cookie_domain_stripper.js
@@ -16,6 +16,7 @@ module.exports = function() {
 
                 // Set modified cookie header for both old & new node.js
                 headers['set-cookie'] = modified;
+                res.removeHeader('set-cookie'); //remove the original header to not have it twice in the response
                 res.setHeader('set-cookie', modified);
             }
 

--- a/test/unit/cases/cookie_domain_stripper_spec.js
+++ b/test/unit/cases/cookie_domain_stripper_spec.js
@@ -20,7 +20,7 @@ describe('cookie_domain_stripper', function() {
     });
 
     it('should strip domain from `set-cookie` header', function () {
-        var res = { writeHead: function() {}, setHeader: function() {} };
+        var res = { writeHead: function() {}, setHeader: function() {}, removeHeader: function() {} };
         var spy = spyOn(res, 'writeHead');
 
         var header = 'GDCAuthSST=x8qtuB7HjE1pJ4xx; path=/gdc/account; domain=secure.gooddata.com; secure; HttpOnly';
@@ -36,8 +36,9 @@ describe('cookie_domain_stripper', function() {
     });
 
     it('should strip domain from `set-cookie` header when headers are passed in response object', function () {
-        var res = { writeHead: function() {}, getHeader: function() { return [header]; }, setHeader: function() {} };
+        var res = { writeHead: function() {}, getHeader: function() { return [header]; }, setHeader: function() {}, removeHeader: function() {} };
         var spy = spyOn(res, 'setHeader');
+        var spy2 = spyOn(res, 'removeHeader');
 
         var header = 'GDCAuthSST=x8qtuB7HjE1pJ4xx; path=/gdc/account; domain=secure.gooddata.com; secure; HttpOnly';
         var modifiedHeader = 'GDCAuthSST=x8qtuB7HjE1pJ4xx; path=/gdc/account; secure; HttpOnly';
@@ -46,6 +47,7 @@ describe('cookie_domain_stripper', function() {
 
         res.writeHead(200);
 
+        expect(spy2).toHaveBeenCalled();
         expect(spy).toHaveBeenCalledWith('set-cookie', [modifiedHeader]);
     });
 });


### PR DESCRIPTION
It's not a big deal, it works, but it's a bit confusing that we send the cookie twice.
